### PR TITLE
Updated the way build.gradle resolves subprojects for android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,15 +34,15 @@ allprojects {
 		builtDate = (new java.text.SimpleDateFormat("yyyy-MM-dd")).format(new Date())
 		oneLineDesc = 'An Open Source XMPP (Jabber) client library'
 		androidProjects = [
-			':smack-tcp',
-			':smack-bosh',
-			':smack-core',
-			':smack-im',
-			':smack-resolver-minidns',
-			':smack-sasl-provided',
-			':smack-extensions',
-			':smack-experimental',
-		].collect{ project(it) }
+			'smack-tcp',
+			'smack-bosh',
+			'smack-core',
+			'smack-im',
+			'smack-resolver-minidns',
+			'smack-sasl-provided',
+			'smack-extensions',
+			'smack-experimental',
+		].collect{ findProject(it) }
 		androidBootClasspath = getAndroidRuntimeJar()
 		androidJavadocOffline = getAndroidJavadocOffline()
 	}


### PR DESCRIPTION
This fixes build problems then you add smack as submodule and subproject to your own gradle based project.
The build failed because the project paths/names were absolute and thus, were only correct if smack was a root project.
Now it doesn't matter if smack is root project or not as subprojects are looked up relatively (by directory name).