### PR TITLE
Proxy mode: add failed address on error

### DIFF
--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -647,6 +647,7 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
                     proxyInfo.getProxySocketConnection().connect(socket, host, port, timeout);
                 } catch (IOException e) {
                     hostAddress.setException(e);
+                    failedAddresses.add(hostAddress);
                     continue;
                 }
                 LOGGER.finer("Established TCP connection to " + hostAndPort);


### PR DESCRIPTION
I've tried the proxy mode of XMPPTCPConnection, and ended up with an empty failed addresses list if the proxy connection failed. This is a fix to restore consistency.