### PR TITLE
Fix HostnameVerifier call for IDNAs

### DIFF
--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -1074,16 +1074,19 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
         void init() {
             done = false;
 
+            final String threadName = "Smack Reader (" + getConnectionCounter() + ')';
             Async.go(new Runnable() {
                 @Override
                 public void run() {
+                    LOGGER.finer(threadName + " start");
                     try {
                         parsePackets();
                     } finally {
+                        LOGGER.finer(threadName + " exit");
                         XMPPTCPConnection.this.readerWriterSemaphore.release();
                     }
                 }
-            }, "Smack Reader (" + getConnectionCounter() + ")");
+            }, threadName);
          }
 
         /**
@@ -1378,16 +1381,19 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
             }
 
             queue.start();
+            final String threadName = "Smack Writer (" + getConnectionCounter() + ')';
             Async.go(new Runnable() {
                 @Override
                 public void run() {
+                    LOGGER.finer(threadName + " start");
                     try {
                         writePackets();
                     } finally {
+                        LOGGER.finer(threadName + " exit");
                         XMPPTCPConnection.this.readerWriterSemaphore.release();
                     }
                 }
-            }, "Smack Writer (" + getConnectionCounter() + ")");
+            }, threadName);
         }
 
         private boolean done() {

--- a/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -141,6 +141,7 @@ import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
 import org.jxmpp.stringprep.XmppStringprepException;
 import org.jxmpp.util.XmppStringUtils;
+import org.minidns.dnsname.DnsName;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
@@ -855,9 +856,12 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
         }
 
         final HostnameVerifier verifier = getConfiguration().getHostnameVerifier();
+        // convert Unicode domain into ASCII Compatible Encoding to match RFC3280 dNSname IA5String constraint
+        // see also: https://bugzilla.mozilla.org/show_bug.cgi?id=280839#c1
+        String ace_domain = DnsName.from(config.getXMPPServiceDomain()).toString();
         if (verifier == null) {
                 throw new IllegalStateException("No HostnameVerifier set. Use connectionConfiguration.setHostnameVerifier() to configure.");
-        } else if (!verifier.verify(getXMPPServiceDomain().toString(), sslSocket.getSession())) {
+        } else if (!verifier.verify(ace_domain, sslSocket.getSession())) {
             throw new CertificateException("Hostname verification of certificate failed. Certificate does not authenticate " + getXMPPServiceDomain());
         }
 


### PR DESCRIPTION
This will replace the Unicode-encoded domain passed to HostNameVerifier.verify() with the punycode-encoded one. According to RFC3280, dNSname fields must contain a subset of ASCII, so Unicode domains must be encoded there.